### PR TITLE
Extract hub setup into references/hub-setup.md and add /upgrade-hub c…

### DIFF
--- a/notion-research-assistant/SKILL.md
+++ b/notion-research-assistant/SKILL.md
@@ -175,6 +175,19 @@ Flag gaps or underrepresented areas.
 
 ---
 
+### /upgrade-hub
+Check whether the Research Hub page is current and update it if the skill has changed.
+
+**Steps:**
+1. Fetch the hub page (`hub_page_id`) and read the version tag from the footer.
+2. Compare to the template version in [`references/hub-setup.md`](references/hub-setup.md).
+3. Describe what changed and ask the user to confirm before rewriting.
+4. Apply hub content updates and/or database schema changes per the upgrade protocol
+   in `references/hub-setup.md`.
+5. Confirm: `✅ Research Hub updated to v[X].`
+
+---
+
 ## Behavioral Rules
 
 ### People profiles — keep them brief
@@ -236,160 +249,9 @@ Then retry the correct `ALTER COLUMN` on the intended field.
 
 ## Research Hub Page
 
-The Research Hub is a Notion page that serves as the documentation and navigation center
-for the entire research system. It links to all four databases and provides a command
-reference guide for the user.
-
-### When to create it
-
-Create the Research Hub page when setting up a new research project from scratch, or
-when the user asks for one. It should be created **after** all four databases exist,
-since it embeds links to them.
-
-### Structure
-
-The Hub page should follow this structure exactly:
-
-```markdown
-# 🔬 Research Hub
-Your persistent research companion. Drop breadcrumbs as you work — quotes, notes,
-people — and interrogate the full body of work any time.
-
----
-
-## 🗄️ Your Databases
-[inline links to all four databases: Sources, Quotes, Notes, People]
-
----
-
-## 🧭 Command Reference
-
-### `/quote` — Save a Direct Quote
-Captures a verbatim quote with full citation info into the 💬 Quotes database.
-
-**Minimal usage:**
-/quote "The limits of my language mean the limits of my world." — Wittgenstein, Tractatus, p. 68
-
-**Full usage:**
-/quote
-text: "The limits of my language mean the limits of my world."
-source: Tractatus Logico-Philosophicus
-author: Ludwig Wittgenstein
-page: 68
-chapter: 5.6
-topics: Theory, Identity
-commentary: Central to the argument about epistemic boundaries
-
-**What Claude stores:** Quote text · Source (linked) · Author · Page number ·
-Chapter · Topics · Your commentary · Date
-
-**Auto-behavior:** When a /quote includes an author name, Claude automatically
-checks the 👤 People database. If no entry exists, Claude researches them via
-web search and creates a profile linked to the quote. No extra command needed.
-
----
-
-### `/source` — Register a Source
-Adds a book, article, or paper to the 📚 Sources database.
-
-**Usage:**
-/source
-title: Discipline and Punish
-author: Michel Foucault
-year: 1975
-type: Book
-publisher: Gallimard
-
-**Auto-behavior:** Claude checks People for the author and creates a profile
-if one doesn't exist.
-
----
-
-### `/note` — Save a Research Insight
-Captures your own thoughts into the 📝 Notes database.
-
-**Minimal usage:**
-/note The framing of "discovery" erases indigenous knowledge systems entirely.
-
-**Full usage:**
-/note
-text: The framing of "discovery" erases indigenous knowledge systems entirely.
-type: Critique
-source: The Invention of Science (Wootton)
-page: 14
-topics: History, Power, Ethics
-
-**Note types:** Insight · Question · Argument · Connection · Critique · Summary
-
----
-
-### `/person` — Research and Save a Person
-Researches a named individual and saves a structured profile to 👤 People.
-Also triggered automatically by /quote and /source.
-
-**Usage:**
-/person Michel Foucault
-/person
-name: Michel Foucault
-relevance: His concept of biopower is central to my argument in Chapter 3
-topics: Power, Theory
-
----
-
-### `/thread [topic]` — Organize Around a Theme
-Pulls all quotes, notes, and people tagged with a topic and synthesizes them.
-
-**Usage:**
-/thread Power
-/thread Nationalism
-
----
-
-### `/by [source title]` — Explore a Source
-Pulls all quotes and notes linked to a specific source.
-
-**Usage:**
-/by Discipline and Punish
-
----
-
-### `/about [person name]` — Explore a Person's Footprint
-Pulls everything connected to a person across all databases.
-
-**Usage:**
-/about Hannah Arendt
-
----
-
-### `/synthesize` — Full Research Synthesis
-Queries all databases and produces a structured thematic overview.
-
-**Usage:**
-/synthesize
-/synthesize around the argument that [X]
-
----
-
-## 💡 Tips
-- **Tags are your threads.** Use Topics multi-select consistently across all entries.
-- **Minimal inputs are fine.** Claude will infer what it can.
-- **People are auto-created.** Any /quote or /source with an author triggers
-  automatic People profile creation if one doesn't exist.
-- **You can add custom topics.** Ask Claude to add new tags any time — they sync
-  across all four databases.
-- **Every entry is linked.** Sources, Quotes, Notes, and People all reference each
-  other, so /thread queries traverse the full graph.
-
----
-*Research Hub built by Claude · [Month Year]*
-```
-
-### How to create it in Notion
-
-Use `notion-create-pages` with the hub page as a standalone workspace page (no parent,
-or under a user-specified parent). Embed the four database links using Notion's
-`<database url="...">` inline syntax. After creation, store the resulting page ID
-in the project's system prompt or memory as `hub_page_id`.
+See [`references/hub-setup.md`](references/hub-setup.md) for the hub page template,
+creation instructions, and the full upgrade protocol (both hub content and database
+schema changes).
 
 ---
 
@@ -398,10 +260,13 @@ in the project's system prompt or memory as `hub_page_id`.
 This skill is intentionally generic. To adapt it for a new research project:
 
 1. Create the four databases (People, Sources, Quotes, Notes) with the schema above
-2. Create the Research Hub page, embedding links to all four databases
+2. Create the Research Hub page using the template in `references/hub-setup.md`
 3. Note the data source collection IDs from each database's `<data-source url="...">` tag
 4. Store the Hub page ID and all four DS IDs in the project's system prompt or memory
 5. The topic taxonomy starts empty — always query before tagging
+
+When the skill is updated and `hub_page_id` is known, run `/upgrade-hub` to bring
+the hub page and database schemas in line with the new version.
 
 The skill's logic, order of operations, and behavioral rules apply regardless of
 the research domain.

--- a/notion-research-assistant/references/hub-setup.md
+++ b/notion-research-assistant/references/hub-setup.md
@@ -1,0 +1,226 @@
+# Research Hub — Setup & Upgrade Guide
+
+The Research Hub is a Notion page that serves as the documentation and navigation center
+for the entire research system. It links to all four databases and provides a command
+reference guide for the user.
+
+**Current template version: v1.0**
+
+The hub footer includes a version tag: `*Research Hub · v1.0 · Built by Claude*`.
+This is used to detect whether an existing hub is out of date.
+
+---
+
+## When to Create
+
+Create the Research Hub page when setting up a new research project from scratch, or
+when the user asks for one. Always create it **after** all four databases exist,
+since it embeds links to them.
+
+---
+
+## How to Create
+
+Use `notion-create-pages` with no parent (or a user-specified parent). Embed the four
+database links using Notion's `<database url="...">` inline syntax.
+
+After creation, store the resulting page ID in project memory as `hub_page_id`.
+
+---
+
+## Hub Page Template
+
+Use the structure below exactly when creating or rewriting the hub.
+
+````markdown
+# 🔬 Research Hub
+Your persistent research companion. Drop breadcrumbs as you work — quotes, notes,
+people — and interrogate the full body of work any time.
+
+---
+
+## 🗄️ Your Databases
+[inline links to all four databases: Sources, Quotes, Notes, People]
+
+---
+
+## 🧭 Command Reference
+
+### `/quote` — Save a Direct Quote
+Captures a verbatim quote with full citation info into the 💬 Quotes database.
+
+**Minimal usage:**
+/quote "The limits of my language mean the limits of my world." — Wittgenstein, Tractatus, p. 68
+
+**Full usage:**
+/quote
+text: "The limits of my language mean the limits of my world."
+source: Tractatus Logico-Philosophicus
+author: Ludwig Wittgenstein
+page: 68
+chapter: 5.6
+topics: Theory, Identity
+commentary: Central to the argument about epistemic boundaries
+
+**What Claude stores:** Quote text · Source (linked) · Author · Page number ·
+Chapter · Topics · Your commentary · Date
+
+**Auto-behavior:** When a /quote includes an author name, Claude automatically
+checks the 👤 People database. If no entry exists, Claude researches them via
+web search and creates a profile linked to the quote. No extra command needed.
+
+---
+
+### `/source` — Register a Source
+Adds a book, article, or paper to the 📚 Sources database.
+
+**Usage:**
+/source
+title: Discipline and Punish
+author: Michel Foucault
+year: 1975
+type: Book
+publisher: Gallimard
+
+**Auto-behavior:** Claude checks People for the author and creates a profile
+if one doesn't exist.
+
+---
+
+### `/note` — Save a Research Insight
+Captures your own thoughts into the 📝 Notes database.
+
+**Minimal usage:**
+/note The framing of "discovery" erases indigenous knowledge systems entirely.
+
+**Full usage:**
+/note
+text: The framing of "discovery" erases indigenous knowledge systems entirely.
+type: Critique
+source: The Invention of Science (Wootton)
+page: 14
+topics: History, Power, Ethics
+
+**Note types:** Insight · Question · Argument · Connection · Critique · Summary
+
+---
+
+### `/person` — Research and Save a Person
+Researches a named individual and saves a structured profile to 👤 People.
+Also triggered automatically by /quote and /source.
+
+**Usage:**
+/person Michel Foucault
+/person
+name: Michel Foucault
+relevance: His concept of biopower is central to my argument in Chapter 3
+topics: Power, Theory
+
+---
+
+### `/thread [topic]` — Organize Around a Theme
+Pulls all quotes, notes, and people tagged with a topic and synthesizes them.
+
+**Usage:**
+/thread Power
+/thread Nationalism
+
+---
+
+### `/by [source title]` — Explore a Source
+Pulls all quotes and notes linked to a specific source.
+
+**Usage:**
+/by Discipline and Punish
+
+---
+
+### `/about [person name]` — Explore a Person's Footprint
+Pulls everything connected to a person across all databases.
+
+**Usage:**
+/about Hannah Arendt
+
+---
+
+### `/synthesize` — Full Research Synthesis
+Queries all databases and produces a structured thematic overview.
+
+**Usage:**
+/synthesize
+/synthesize around the argument that [X]
+
+---
+
+### `/upgrade-hub` — Update This Page
+Checks whether this hub page matches the current skill version and rewrites it
+if the template has changed. Run after updating the skill.
+
+---
+
+## 💡 Tips
+- **Tags are your threads.** Use Topics multi-select consistently across all entries.
+- **Minimal inputs are fine.** Claude will infer what it can.
+- **People are auto-created.** Any /quote or /source with an author triggers
+  automatic People profile creation if one doesn't exist.
+- **You can add custom topics.** Ask Claude to add new tags any time — they sync
+  across all four databases.
+- **Every entry is linked.** Sources, Quotes, Notes, and People all reference each
+  other, so /thread queries traverse the full graph.
+
+---
+*Research Hub · v1.0 · Built by Claude · [Month Year]*
+````
+
+---
+
+## Skill Upgrade Protocol
+
+Skill upgrades can affect two distinct layers: the **hub page content** (command
+reference, tips) and the **database schemas** (fields, types, relations). Both
+require different remediation steps.
+
+### Detecting that an upgrade is needed
+
+When `hub_page_id` is known:
+1. Fetch the hub page
+2. Look for the version tag in the footer (e.g., `v1.0`)
+3. Compare to the current template version at the top of this file
+4. If they differ, or if no version tag is found, an upgrade is needed
+
+### Hub content upgrade (command reference changed)
+
+Triggered when: new commands were added, command syntax changed, or tips were updated.
+
+**Steps:**
+1. Fetch the current hub page with `notion-fetch`
+2. Confirm with the user: "The hub page is on v[X], current template is v[Y].
+   Shall I rewrite it with the updated command reference?"
+3. On confirmation, use `notion-update-page` with `command: replace_content` and
+   the full hub template above
+4. Confirm: `✅ Research Hub updated to v[Y].`
+
+### Schema upgrade (database fields changed)
+
+Triggered when: new fields were added to one or more of the four databases, field
+types changed, or relations were added.
+
+**Steps:**
+1. Identify which databases are affected (People, Sources, Quotes, Notes)
+2. For each affected database, describe the change to the user:
+   - Added fields and their types
+   - Removed or renamed fields
+   - New relation targets
+3. Ask for confirmation before running any DDL
+4. Apply changes using `notion-update-data-source` with the appropriate
+   `ADD COLUMN`, `DROP COLUMN`, or `ALTER COLUMN` statements
+5. If new tags are needed in `Topics`, sync them across all four databases
+   per the topic tag rules in `SKILL.md`
+6. After all schema changes are applied, check whether the hub content also
+   needs updating (new fields may warrant a tips update)
+7. Confirm each change individually: `✅ Sources schema updated.`, etc.
+
+### Combined upgrade (both hub and schema)
+
+Apply schema changes first, then rewrite the hub. This ensures the hub reflects
+the final database structure.


### PR DESCRIPTION
…ommand

Move the inline Research Hub page template and creation instructions out of SKILL.md into a dedicated references/hub-setup.md supporting file. The hub is a one-time setup artifact (or upgraded on skill version bumps), so keeping its full template in the main skill body was adding ~160 lines of low-signal context to every invocation.

Key changes:
- Add references/hub-setup.md with the hub template (now versioned at v1.0 via a footer tag), creation steps, and a skill upgrade protocol covering hub content changes, database schema migrations, and combined upgrades
- Add /upgrade-hub command to SKILL.md that reads the hub footer version, diffs against hub-setup.md, and applies hub + schema changes with user confirmation before each step
- Replace the inline hub section in SKILL.md with a two-line pointer to references/hub-setup.md; SKILL.md drops from 407 to 271 lines